### PR TITLE
Redo asset config

### DIFF
--- a/config.py
+++ b/config.py
@@ -162,24 +162,20 @@ class Config:
 
     # Static assets:
 
-    # E.g. 22.10
-    ISE_VERSION = os.getenv("ISE_VERSION")
+    ISE_VERSION = os.getenv("ISE_VERSION", "23.0")
     # boolean: false means serve via jsdelivr
     ISE_SERVE_LOCALLY = bool(int(os.getenv("ISE_SERVE_LOCALLY", 1)))
     ISE_SERVE_MINIFIED = bool(int(os.getenv("ISE_SERVE_MINIFIED", 0)))
 
-    # E.g. 0.8.1
-    ELKJS_VERSION = os.getenv("ELKJS_VERSION")
+    ELKJS_VERSION = os.getenv("ELKJS_VERSION", "0.8.1")
     # boolean: false means serve via jsdelivr
     ELKJS_SERVE_LOCALLY = bool(int(os.getenv("ELKJS_SERVE_LOCALLY", 0)))
 
-    # E.g. 3.0.1
-    MATHJAX_VERSION = os.getenv("MATHJAX_VERSION")
+    MATHJAX_VERSION = os.getenv("MATHJAX_VERSION", "3.0.1")
     # boolean: false means serve via jsdelivr
     MATHJAX_SERVE_LOCALLY = bool(int(os.getenv("MATHJAX_SERVE_LOCALLY", 0)))
 
-    # E.g. 0.19.1
-    PYODIDE_VERSION = os.getenv("PYODIDE_VERSION")
+    PYODIDE_VERSION = os.getenv("PYODIDE_VERSION", "0.21.0")
     # boolean: false means serve via jsdelivr
     PYODIDE_SERVE_LOCALLY = bool(int(os.getenv("PYODIDE_SERVE_LOCALLY", 0)))
 
@@ -207,7 +203,7 @@ class Config:
     #
     # To load all wheels from pfsc-server via static URLs, define LOCAL_WHL_FILENAMES
     # to be a comma-delimited list of wheel filenames, e.g. displaylang-0.1.0-py3-none-any.whl
-    PFSC_EXAMP_VERS_NUM = os.getenv("PFSC_EXAMP_VERS_NUM")
+    PFSC_EXAMP_VERS_NUM = os.getenv("PFSC_EXAMP_VERS_NUM", "0.22.7")
     LOCAL_WHL_FILENAMES = parse_cd_list(os.getenv('LOCAL_WHL_FILENAMES', ''))
 
     # See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy>

--- a/config.py
+++ b/config.py
@@ -161,13 +161,15 @@ class Config:
     PROXY_FIX_PROTO = int(os.getenv("PROXY_FIX_PROTO", 0))
 
     # Static assets:
-    # The static assets can be served locally from `/static/...` URLs (the default),
-    # or from a CDN by setting alternative URLs here.
 
-    # E.g. https://cdn.jsdelivr.net/gh/alpinemath/pfsc-ise@22.8/dist/ise.bundle.min.js
-    ISE_JS_URL = os.getenv("ISE_JS_URL")
-    # E.g. https://cdn.jsdelivr.net/gh/alpinemath/pfsc-ise@22.8/dist/mathworker.bundle.min.js
-    ISE_MATHWORKER_JS_URL = os.getenv("ISE_MATHWORKER_JS_URL")
+    # E.g. 22.10
+    ISE_VERSION = os.getenv("ISE_VERSION")
+    # boolean: false means serve via jsdelivr
+    ISE_SERVE_LOCALLY = bool(int(os.getenv("ISE_SERVE_LOCALLY", 1)))
+    ISE_SERVE_MINIFIED = bool(int(os.getenv("ISE_SERVE_MINIFIED", 0)))
+
+    # Supporting JS modules can be served locally from `/static/...` URLs (the default),
+    # or from a CDN by setting alternative URLs here.
     # E.g. https://cdn.jsdelivr.net/npm/elkjs@0.8.1/lib/elk.bundled.js
     ELK_JS_URL = os.getenv("ELK_JS_URL")
     # E.g. https://cdn.jsdelivr.net/npm/mathjax@3.0.1/es5/tex-svg.js
@@ -175,8 +177,14 @@ class Config:
 
     # E.g. 0.19.1
     PYODIDE_VERSION = os.getenv("PYODIDE_VERSION")
-    # boolean
+    # boolean: false means serve via jsdelivr
     PYODIDE_SERVE_LOCALLY = bool(int(os.getenv("PYODIDE_SERVE_LOCALLY", 0)))
+
+    # Since a worker script must obey the same-origin policy
+    #   https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker
+    # we cannot serve the mathworker script over a CDN. However, we can decide
+    # whether to serve it minified or not.
+    MATHWORKER_SERVE_MINIFIED = bool(int(os.getenv("MATHWORKER_SERVE_MINIFIED", 1)))
 
     # When loading locally from `/static/...`, some assets have a debug version.
     ELK_DEBUG = bool(int(os.getenv("ELK_DEBUG", 0)))
@@ -495,6 +503,8 @@ class DevelopmentConfig(Config):
     EMAIL_BRANDING_IMG_TITLE = 'Some Website'
     HOSTING_PHRASE = 'on our website'
     HOSTING_REQ_REVIEWER_ADDRS = ['reviewer1@localhost', 'reviewer2@localhost']
+
+    MATHWORKER_SERVE_MINIFIED = bool(int(os.getenv("MATHWORKER_SERVE_MINIFIED", 0)))
 
 
 class LocalDevConfig(DevelopmentConfig):

--- a/config.py
+++ b/config.py
@@ -172,35 +172,32 @@ class Config:
     ELK_JS_URL = os.getenv("ELK_JS_URL")
     # E.g. https://cdn.jsdelivr.net/npm/mathjax@3.0.1/es5/tex-svg.js
     MATHJAX_JS_URL = os.getenv("MATHJAX_JS_URL")
-    # E.g. https://cdn.jsdelivr.net/pyodide/v0.19.0/full/
-    PYODIDE_INDEX_URL = os.getenv("PYODIDE_INDEX_URL")
+
+    # E.g. 0.19.1
+    PYODIDE_VERSION = os.getenv("PYODIDE_VERSION")
+    # boolean
+    PYODIDE_SERVE_LOCALLY = bool(int(os.getenv("PYODIDE_SERVE_LOCALLY", 0)))
 
     # When loading locally from `/static/...`, some assets have a debug version.
     ELK_DEBUG = bool(int(os.getenv("ELK_DEBUG", 0)))
 
     # Micropip install targets:
-    # Python wheels loaded by Pyodide in the client can come from three different
-    # types of sources: (a) as a static asset served by pfsc-server, (b) from a
-    # CDN or other external URL, and (c) from PyPI. The defaults defined here are
-    # of type (a), which is useful when running the server locally. They are recognized
-    # as being of type (a), because they end with `.whl` and do *not* begin with `https:`.
-    # They give only the name of the whl file, which includes the desired version
-    # number for each package. These files must be made available in the `/whl` subdirectory
-    # of the server's static folder. The server will add the necessary prefix to make a
-    # full URL. If you want type (b), the string should end with `.whl` and begin with `https:`.
-    # For example,
-    #   https://cdn.jsdelivr.net/gh/alpinemath/sympy@1.11.dev0/sympy-1.11.dev0-py3-none-any.whl
-    # If you want type (c), use a <name>==<version> string as you would ordinarily pass to pip.
-    # For example,
-    #   typeguard==2.13.3
-    # For a type (c) installation to work, PyPI must be hosting a `-py3-none-any.whl` file
-    # for the requested version. (Check under the "Download files" tab on PyPI.)
-    PYO_WHL_PFSC_UTIL = os.getenv("PYO_WHL_PFSC_UTIL", "pfsc_util-0.22.0-py3-none-any.whl")
-    PYO_WHL_TYPEGUARD = os.getenv("PYO_WHL_TYPEGUARD", "typeguard-0.0.0-py3-none-any.whl")
-    PYO_WHL_DISPLAYLANG = os.getenv("PYO_WHL_DISPLAYLANG", "displaylang-0.1.0-py3-none-any.whl")
-    PYO_WHL_SYMPY = os.getenv("PYO_WHL_SYMPY", "sympy-1.11.dev0-py3-none-any.whl")
-    PYO_WHL_LARK = os.getenv("PYO_WHL_LARK", "lark067-0.6.7-py2.py3-none-any.whl")
-    PYO_WHL_PFSC_EXAMP = os.getenv("PYO_WHL_PFSC_EXAMP", "pfsc_examp-0.22.0-py3-none-any.whl")
+    #
+    # Python wheels will be loaded by Pyodide in the client in one of two ways:
+    # Either we pull pfsc-examp from PyPI, and let micropip automatically resolve
+    # its dependencies and pull those too from PyPI; or all wheels will be loaded
+    # via static URLs pointing into pfsc-server. Generally speaking, the former
+    # is what you want when running an online web app, while the latter is
+    # appropriate both when running the OCA, and during development.
+    #
+    # To load all wheels from PyPI, you must define PFSC_EXAMP_VERS_NUM,
+    # whose value should be a string like "0.22.7", and you must _not_ define
+    # LOCAL_WHL_FILENAMES.
+    #
+    # To load all wheels from pfsc-server via static URLs, define LOCAL_WHL_FILENAMES
+    # to be a comma-delimited list of wheel filenames, e.g. displaylang-0.1.0-py3-none-any.whl
+    PFSC_EXAMP_VERS_NUM = os.getenv("PFSC_EXAMP_VERS_NUM")
+    LOCAL_WHL_FILENAMES = parse_cd_list(os.getenv('LOCAL_WHL_FILENAMES', ''))
 
     # See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy>
     REFERRER_POLICY = os.getenv("REFERRER_POLICY", 'no-referrer')

--- a/config.py
+++ b/config.py
@@ -168,12 +168,15 @@ class Config:
     ISE_SERVE_LOCALLY = bool(int(os.getenv("ISE_SERVE_LOCALLY", 1)))
     ISE_SERVE_MINIFIED = bool(int(os.getenv("ISE_SERVE_MINIFIED", 0)))
 
-    # Supporting JS modules can be served locally from `/static/...` URLs (the default),
-    # or from a CDN by setting alternative URLs here.
-    # E.g. https://cdn.jsdelivr.net/npm/elkjs@0.8.1/lib/elk.bundled.js
-    ELK_JS_URL = os.getenv("ELK_JS_URL")
-    # E.g. https://cdn.jsdelivr.net/npm/mathjax@3.0.1/es5/tex-svg.js
-    MATHJAX_JS_URL = os.getenv("MATHJAX_JS_URL")
+    # E.g. 0.8.1
+    ELKJS_VERSION = os.getenv("ELKJS_VERSION")
+    # boolean: false means serve via jsdelivr
+    ELKJS_SERVE_LOCALLY = bool(int(os.getenv("ELKJS_SERVE_LOCALLY", 0)))
+
+    # E.g. 3.0.1
+    MATHJAX_VERSION = os.getenv("MATHJAX_VERSION")
+    # boolean: false means serve via jsdelivr
+    MATHJAX_SERVE_LOCALLY = bool(int(os.getenv("MATHJAX_SERVE_LOCALLY", 0)))
 
     # E.g. 0.19.1
     PYODIDE_VERSION = os.getenv("PYODIDE_VERSION")
@@ -609,8 +612,10 @@ class OcaConfig(DockerDevConfig):
     APP_URL_PREFIX = "/ProofscapeISE"
 
     ISE_SERVE_LOCALLY = True
-    ISE_SERVE_MINIFIED = False
+    ELKJS_SERVE_LOCALLY = True
+    MATHJAX_SERVE_LOCALLY = True
     PYODIDE_SERVE_LOCALLY = True
+    ISE_SERVE_MINIFIED = False
     MATHWORKER_SERVE_MINIFIED = False
 
     # Later we may set up demo repos for use in the OCA, but for now it's disabled.

--- a/config.py
+++ b/config.py
@@ -197,13 +197,13 @@ class Config:
     # is what you want when running an online web app, while the latter is
     # appropriate both when running the OCA, and during development.
     #
-    # To load all wheels from PyPI, you must define PFSC_EXAMP_VERS_NUM,
+    # To load all wheels from PyPI, you must define PFSC_EXAMP_VERSION,
     # whose value should be a string like "0.22.7", and you must _not_ define
     # LOCAL_WHL_FILENAMES.
     #
     # To load all wheels from pfsc-server via static URLs, define LOCAL_WHL_FILENAMES
     # to be a comma-delimited list of wheel filenames, e.g. displaylang-0.1.0-py3-none-any.whl
-    PFSC_EXAMP_VERS_NUM = os.getenv("PFSC_EXAMP_VERS_NUM", "0.22.7")
+    PFSC_EXAMP_VERSION = os.getenv("PFSC_EXAMP_VERSION", "0.22.7")
     LOCAL_WHL_FILENAMES = parse_cd_list(os.getenv('LOCAL_WHL_FILENAMES', ''))
 
     # See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy>

--- a/config.py
+++ b/config.py
@@ -608,6 +608,11 @@ class OcaConfig(DockerDevConfig):
     # Browser Extension).
     APP_URL_PREFIX = "/ProofscapeISE"
 
+    ISE_SERVE_LOCALLY = True
+    ISE_SERVE_MINIFIED = False
+    PYODIDE_SERVE_LOCALLY = True
+    MATHWORKER_SERVE_MINIFIED = False
+
     # Later we may set up demo repos for use in the OCA, but for now it's disabled.
     # Issues include:
     #  * shouldn't try to delete after 24h (or ever), because

--- a/pfsc/__init__.py
+++ b/pfsc/__init__.py
@@ -124,6 +124,7 @@ def make_app(config_name=None):
     GRAPHDB_URI
     PFSC_LIB_ROOT
     SECRET_KEY
+    ISE_VERSION
     PYODIDE_VERSION
     """.split()
     num_ev = len(essential_vars)

--- a/pfsc/__init__.py
+++ b/pfsc/__init__.py
@@ -125,6 +125,8 @@ def make_app(config_name=None):
     PFSC_LIB_ROOT
     SECRET_KEY
     ISE_VERSION
+    ELKJS_VERSION
+    MATHJAX_VERSION
     PYODIDE_VERSION
     """.split()
     num_ev = len(essential_vars)

--- a/pfsc/__init__.py
+++ b/pfsc/__init__.py
@@ -124,10 +124,6 @@ def make_app(config_name=None):
     GRAPHDB_URI
     PFSC_LIB_ROOT
     SECRET_KEY
-    ISE_VERSION
-    ELKJS_VERSION
-    MATHJAX_VERSION
-    PYODIDE_VERSION
     """.split()
     num_ev = len(essential_vars)
     # Some config vars can be undefined in development, but must have a value
@@ -150,13 +146,6 @@ def make_app(config_name=None):
     # one of these two things is true:
     if not app.config.get("BUILD_IN_GDB") and not app.config.get("PFSC_BUILD_ROOT"):
         msg = 'Either `PFSC_BUILD_ROOT` must be defined, or `BUILD_IN_GDB` must be enabled.'
-        msg += ' Review app configuration.'
-        raise PfscExcep(msg, PECode.ESSENTIAL_CONFIG_VAR_UNDEFINED)
-
-    # Wheels?
-    # Either they must all come from PyPI, or must be served locally.
-    if not app.config.get("PFSC_EXAMP_VERS_NUM") and not app.config.get("LOCAL_WHL_FILENAMES"):
-        msg = 'Either `PFSC_EXAMP_VERS_NUM` or `LOCAL_WHL_FILENAMES` must be defined.'
         msg += ' Review app configuration.'
         raise PfscExcep(msg, PECode.ESSENTIAL_CONFIG_VAR_UNDEFINED)
 

--- a/pfsc/__init__.py
+++ b/pfsc/__init__.py
@@ -124,6 +124,7 @@ def make_app(config_name=None):
     GRAPHDB_URI
     PFSC_LIB_ROOT
     SECRET_KEY
+    PYODIDE_VERSION
     """.split()
     num_ev = len(essential_vars)
     # Some config vars can be undefined in development, but must have a value
@@ -146,6 +147,13 @@ def make_app(config_name=None):
     # one of these two things is true:
     if not app.config.get("BUILD_IN_GDB") and not app.config.get("PFSC_BUILD_ROOT"):
         msg = 'Either `PFSC_BUILD_ROOT` must be defined, or `BUILD_IN_GDB` must be enabled.'
+        msg += ' Review app configuration.'
+        raise PfscExcep(msg, PECode.ESSENTIAL_CONFIG_VAR_UNDEFINED)
+
+    # Wheels?
+    # Either they must all come from PyPI, or must be served locally.
+    if not app.config.get("PFSC_EXAMP_VERS_NUM") and not app.config.get("LOCAL_WHL_FILENAMES"):
+        msg = 'Either `PFSC_EXAMP_VERS_NUM` or `LOCAL_WHL_FILENAMES` must be defined.'
         msg += ' Review app configuration.'
         raise PfscExcep(msg, PECode.ESSENTIAL_CONFIG_VAR_UNDEFINED)
 

--- a/pfsc/handlers/app.py
+++ b/pfsc/handlers/app.py
@@ -796,18 +796,26 @@ class AppLoader(Handler):
 
         ise_bundle_filename = f'ise.bundle{".min." if check_config("ISE_SERVE_MINIFIED") else "."}js'
         ise_vers = check_config("ISE_VERSION")
+        elk_vers = check_config("ELKJS_VERSION")
+        mathjax_vers = check_config("MATHJAX_VERSION")
 
         js = [
             # MathJax
-            (check_config("MATHJAX_JS_URL") or
-             url_for('static', filename='mathjax/tex-svg.js')),
+            (
+                url_for('static', filename=f'mathjax/v{mathjax_vers}/tex-svg.js')
+                if check_config("MATHJAX_SERVE_LOCALLY") else
+                f'https://cdn.jsdelivr.net/npm/mathjax@{mathjax_vers}/es5/tex-svg.js'
+            ),
 
             # ELK.js
-            (check_config("ELK_JS_URL") or
-             url_for(
-                 'static',
-                 filename=f'elk/elk{"-api" if check_config("ELK_DEBUG") else ".bundled"}.js'
-             )),
+            (
+                url_for(
+                    'static',
+                    filename=f'elk/v{elk_vers}/elk{"-api" if check_config("ELK_DEBUG") else ".bundled"}.js'
+                )
+                if check_config("ELKJS_SERVE_LOCALLY") else
+                f'https://cdn.jsdelivr.net/npm/elkjs@{elk_vers}/lib/elk.bundled.js'
+            ),
             # If using KLay instead of ELK:
             # url_for('static', filename='klay/klay.js'),
 

--- a/pfsc/handlers/app.py
+++ b/pfsc/handlers/app.py
@@ -860,7 +860,7 @@ class AppLoader(Handler):
 
             "micropipInstallTargets": [
                 adapt_wheel_target(fn) for fn in local_whl_filenames
-            ] or [f'pfsc-examp=={check_config("PFSC_EXAMP_VERS_NUM")}'],
+            ] or [f'pfsc-examp=={check_config("PFSC_EXAMP_VERSION")}'],
 
             "micropipNoDeps": micropip_no_deps,
         }

--- a/pfsc/handlers/app.py
+++ b/pfsc/handlers/app.py
@@ -794,6 +794,9 @@ class AppLoader(Handler):
     def write_html(ISE_state):
         css = []
 
+        ise_bundle_filename = f'ise.bundle{".min." if check_config("ISE_SERVE_MINIFIED") else "."}js'
+        ise_vers = check_config("ISE_VERSION")
+
         js = [
             # MathJax
             (check_config("MATHJAX_JS_URL") or
@@ -809,8 +812,11 @@ class AppLoader(Handler):
             # url_for('static', filename='klay/klay.js'),
 
             # the ISE bundle
-            (check_config("ISE_JS_URL") or
-             url_for('static', filename='ise.bundle.js')),
+            (
+                url_for('static', filename=f'ise/v{ise_vers}/{ise_bundle_filename}')
+                if check_config("ISE_SERVE_LOCALLY") else
+                f'https://cdn.jsdelivr.net/gh/alpinemath/pfsc-ise@{ise_vers}/dist/{ise_bundle_filename}'
+            ),
 
             # If we want to use pdfjs outside of iframes, might need sth like this:
             # url_for('static', filename='pdfjs/build/pdf.js'),
@@ -826,6 +832,7 @@ class AppLoader(Handler):
         can_control_deps = int(pyodide_vers.split('.')[1]) >= 21
         local_whl_filenames = check_config("LOCAL_WHL_FILENAMES")
         micropip_no_deps = can_control_deps and len(local_whl_filenames) > 0
+        mathworker_bundle_filename = f'mathworker.bundle{".min." if check_config("MATHWORKER_SERVE_MINIFIED") else "."}js'
 
         examp_config = {
             "vars": {
@@ -835,10 +842,7 @@ class AppLoader(Handler):
                 "MAX_DISPLAY_BUILD_DEPTH": check_config("MAX_DISPLAY_BUILD_DEPTH"),
             },
 
-            "mathworkerURL": (
-                check_config("ISE_MATHWORKER_JS_URL") or
-                url_for('static', filename='mathworker.bundle.js')
-            ),
+            "mathworkerURL": url_for('static', filename=f'ise/v{ise_vers}/{mathworker_bundle_filename}'),
 
             "pyodideIndexURL": (
                 url_for('static', filename=f'pyodide/v{pyodide_vers}')

--- a/pfsc/templates/base.html
+++ b/pfsc/templates/base.html
@@ -19,7 +19,9 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
+    {% with ise_vers = config["ISE_VERSION"] %}
+    <link rel="shortcut icon" href="{{ url_for('static', filename='ise/v'+ise_vers+'/favicon.ico') }}">
+    {% endwith %}
     {% if title %}
         <title>{{ title }}</title>
     {% else %}


### PR DESCRIPTION
* Serve all static assets from URLs including version numbers, whether being served locally (as for the OCA), or over a CDN.
* Remove the option to try to serve the mathworker JS remotely -- `Worker` constructor requires script from same origin.
* Simplify the config for the wheels that run under Pyodide.

To do all this, we make breaking changes in the set of config vars.