### PR TITLE
Improve URL resolution

### DIFF
--- a/pfsc/blueprints/docs.py
+++ b/pfsc/blueprints/docs.py
@@ -33,4 +33,4 @@ bp = Blueprint('docs', __name__)
 
 @bp.route('/Tutorial', methods=["GET"])
 def zb119_tutorial():
-    return redirect('https://pise.alpinemath.org/?sd=c289&tt=b&a=0;0&c=gh.alpinemath.docs@0_1_0.pise.tutorial.zb119~b.tutorial~a(g0t0)')
+    return redirect('/?sd=c289&tt=b&a=0;0&c=gh.alpinemath.docs.pise.tutorial.zb119~b.tutorial~a(g0t0)')

--- a/pfsc/build/repo.py
+++ b/pfsc/build/repo.py
@@ -117,6 +117,24 @@ class RepoInfo:
             pfsc.constants.SHADOW_PREFIX + self.project
         )
 
+    def get_default_version(self):
+        """
+        Determine the default version for this repo (which means the version to
+        be loaded/opened if the user failed to specify a version).
+
+        :return: full version string
+        """
+        vers_str = pfsc.constants.WIP_TAG
+        if self.is_demo():
+            # Default version is always WIP, for a demo repo.
+            pass
+        elif check_config("DEFAULT_REPO_VERSION_IS_LATEST_RELEASE"):
+            from pfsc.gdb import get_graph_reader
+            vi = get_graph_reader().get_versions_indexed(self.libpath, include_wip=False)
+            if len(vi) > 0:
+                vers_str = vi[-1].get('version', pfsc.constants.WIP_TAG)
+        return vers_str
+
     def clean(self):
         # Note: This is only used by testing code (not in production), so it is
         # okay to use CLI git here.

--- a/pfsc/build/repo.py
+++ b/pfsc/build/repo.py
@@ -539,15 +539,22 @@ def make_repo_versioned_libpath(libpath, version):
     return f'{repo_part}@{version.replace(".", "_")}{libpath[len(repo_part):]}'
 
 
-def parse_repo_versioned_libpath(rvlp):
+def parse_repo_versioned_libpath(rvlp, provide_default=False):
     """
     :param rvlp: a repo-versioned libpath
+    :param provide_default: if True, and the supposed repo-versioned libpath
+        in fact fails to include a version, then we provide the default version
+        for this repo; if False, we instead raise an exception.
     :return: pair libpath, version
     """
     versioned_repo_part = get_repo_part(rvlp)
     p = versioned_repo_part.split("@")
     if len(p) != 2:
-        raise PfscExcep(f"Malformed versioned segment: `{versioned_repo_part}`", PECode.MALFORMED_VERSIONED_LIBPATH)
+        if len(p) == 1 and provide_default:
+            ri = RepoInfo(p[0])
+            p.append(ri.get_default_version())
+        else:
+            raise PfscExcep(f"Malformed versioned segment: `{versioned_repo_part}`", PECode.MALFORMED_VERSIONED_LIBPATH)
     repo_part, underscore_version = p
     remainder = rvlp[len(versioned_repo_part):]
     libpath = repo_part + remainder

--- a/pfsc/contenttree/__init__.py
+++ b/pfsc/contenttree/__init__.py
@@ -89,7 +89,7 @@ from lark import Lark, Transformer
 import pfsc.constants
 from pfsc.build.versions import VersionTag
 from pfsc.build.lib.libpath import get_modpath
-from pfsc.build.repo import parse_repo_versioned_libpath
+from pfsc.build.repo import parse_repo_versioned_libpath, make_repo_versioned_libpath
 from pfsc.excep import PfscExcep, PECode
 from pfsc.session import make_demo_user_path
 
@@ -400,6 +400,10 @@ class AugmentedLibpath:
         :param libpath: str
         :param codes: list of TreeCode instances
         """
+        # Ensure that we have a version, using default for repo if necessary.
+        libpath, version = parse_repo_versioned_libpath(libpath, provide_default=True)
+        libpath = make_repo_versioned_libpath(libpath, version)
+
         self.libpath = libpath
         self.codes = codes
 

--- a/pfsc/handlers/repo.py
+++ b/pfsc/handlers/repo.py
@@ -28,7 +28,6 @@ from pfsc.excep import PfscExcep, PECode
 from pfsc.handlers import RepoTaskHandler
 from pfsc.checkinput import IType
 from pfsc.checkinput.version import check_full_version
-from pfsc.gdb import get_graph_reader
 from pfsc.build import build_module, build_release
 from pfsc.build.manifest import has_manifest, load_manifest
 from pfsc.build.repo import RepoInfo
@@ -102,15 +101,7 @@ class RepoLoader(RepoTaskHandler):
         self.repo_info = ri = RepoInfo(repopath.value)
 
         if vers is None:
-            # If client didn't specify a version, we have to select the default.
-            vers_str = pfsc.constants.WIP_TAG
-            if ri.is_demo():
-                # Default version is always WIP, for a demo repo.
-                pass
-            elif check_config("DEFAULT_REPO_VERSION_IS_LATEST_RELEASE"):
-                vi = get_graph_reader().get_versions_indexed(repopath.value, include_wip=False)
-                if len(vi) > 0:
-                    vers_str = vi[-1].get('version', pfsc.constants.WIP_TAG)
+            vers_str = ri.get_default_version()
             vers = check_full_version('', vers_str, {})
         self.version = vers.full
         self.is_wip = vers.isWIP

--- a/tests/test_app_loader.py
+++ b/tests/test_app_loader.py
@@ -349,6 +349,74 @@ gen_args_3 = {
     "c": "test.hist.lit@3_1_4.H.ilbert.ZB~b.Thm9.Pf~c(g0t0*g1t0G1*g1t1G1)"
 }
 
+# This one is the same as state_2, except that the version is WIP.
+# This is for testing that the default version will be provided if omitted in
+# the original URL args. Note that in the generated version of the args, the
+# `@W` version has been added for us.
+args_4 = {
+    "a": "0;0",
+    "c": "test.hist.lit.H.ilbert.ZB~b.Thm9.Pf~c(g0t0)"
+}
+gen_args_4 = {
+    "a": "0;0",
+    "c": "test.hist.lit@W.H.ilbert.ZB~b.Thm9.Pf~c(g0t0)"
+}
+state_4 = """\
+{
+    "autoSaveDelay": 30000,
+    "reloadFromDisk": "auto",
+    "saveAllOnAppBlur": true,
+    "enablePdfProxy": false,
+    "offerPdfLibrary": false,
+    "allowWIP": true,
+    "appUrlPrefix": "",
+    "devMode": false,
+    "personalServerMode": false,
+    "ssnrAvailable": false,
+    "hostingByRequest": true,
+    "tosURL": null,
+    "tosVersion": null,
+    "prpoURL": null,
+    "prpoVersion": null,
+    "err_lvl": 0,
+    "content": {
+        "tctStructure": [
+            "L"
+        ],
+        "tctSizeFractions": [],
+        "activeTcIndex": 0,
+        "tcs": [
+            {
+                "tabs": [
+                    {
+                        "type": "CHART",
+                        "on_board": [
+                            "test.hist.lit.H.ilbert.ZB.Thm9.Pf"
+                        ],
+                        "versions": {
+                            "test.hist.lit.H.ilbert.ZB.Thm9.Pf": "WIP"
+                        },
+                        "gid": "0"
+                    }
+                ],
+                "activeTab": 0
+            }
+        ]
+    },
+    "trees": {
+        "trees": {
+            "test.hist.lit@WIP": {
+                "expand": {
+                    "buildNodeIds": [
+                        "test.hist.lit.H.ilbert.ZB"
+                    ]
+                }
+            }
+        }
+    }
+}"""
+
+
 def normalize_gids(state):
     gids = []
     for tc in state["content"]["tcs"]:
@@ -376,6 +444,7 @@ def normalize_gids(state):
     (args_1, state_1),
     (gen_args_2, state_2),
     (gen_args_3, state_3),
+    (args_4, state_4),
 ))
 def test_app_loader(app, args, expected):
     with app.app_context():
@@ -412,6 +481,7 @@ def test_app_loader_2(app):
     (state_1, gen_args_1),
     (state_2, gen_args_2),
     (state_3, gen_args_3),
+    (state_4, gen_args_4),
 ))
 def test_arg_maker(app, state, expected):
     print()


### PR DESCRIPTION
* When parsing URL args, supply default repo versions where omitted
* Improve the `/docs/Tutorial` redirect
  - Omit version number so we always get the latest (on servers where latest is configured as default)
  - Make relative